### PR TITLE
Update DS3231.cpp

### DIFF
--- a/DS3231.cpp
+++ b/DS3231.cpp
@@ -21,7 +21,9 @@
 ////////////////////////////////////////////////////////////////////////////////
 // utility code, some of this could be exposed in the DateTime API if needed
 
-static uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 };
+// const added since the Linux IDE compiler signals an error without it
+// Apr.30, 2014 smarkon
+static const uint8_t daysInMonth [] PROGMEM = { 31,28,31,30,31,30,31,31,30,31,30,31 };
 
 // number of days since 2000/01/01, valid for 2001..2099
 static uint16_t date2days(uint16_t y, uint8_t m, uint8_t d) {


### PR DESCRIPTION
The current Linux Arduino IDE signals an error if we do not declare daysInMonth a constant.
